### PR TITLE
fix compilation error on esp32

### DIFF
--- a/KnxTpUart/KnxTelegram.cpp
+++ b/KnxTpUart/KnxTelegram.cpp
@@ -354,7 +354,7 @@ void KnxTelegram::set2ByteFloatValue(float value) {
   int exponent = 0;
   for (; v < -2048.0f; v /= 2) exponent++;
   for (; v > 2047.0f; v /= 2) exponent++;
-  long m = round(v) & 0x7FF;
+  long m = (int)round(v) & 0x7FF;
   short msb = (short) (exponent << 3 | m >> 8);
   if (value < 0.0f) msb |= 0x80;
   buffer[8] = msb;

--- a/KnxTpUart/KnxTpUart.cpp
+++ b/KnxTpUart/KnxTpUart.cpp
@@ -526,7 +526,7 @@ int KnxTpUart::serialRead() {
 #endif
 
   while (! (_serialport->available() > 0)) {
-    if (abs(millis() - startTime) > SERIAL_READ_TIMEOUT_MS) {
+    if ((millis() - startTime) > SERIAL_READ_TIMEOUT_MS) {
       // Timeout
 #if defined(TPUART_DEBUG)
       TPUART_DEBUG_PORT.println("Timeout while receiving message");


### PR DESCRIPTION
I was getting the following error when trying to compile on an ESP32;

```
D:\projects\arduino\libraries\KnxTpUart\KnxTelegram.cpp: In member function 'void KnxTelegram::set2ByteFloatValue(float)':
D:\projects\arduino\libraries\KnxTpUart\KnxTelegram.cpp:357:23: error: invalid operands of types 'double' and 'int' to binary 'operator&'
   long m = round(v) & 0x7FF;
```

After applying my fix the error went away, but I have been unable to test as I only have binary devices on my KNX bus.